### PR TITLE
Endpoint - leagues-by-continent

### DIFF
--- a/src/main/java/com/football/api/config/Constants.java
+++ b/src/main/java/com/football/api/config/Constants.java
@@ -1,0 +1,6 @@
+package com.football.api.config;
+
+public class Constants {
+
+    public static final String VALID_CONTINENT_VALUES = "^(([e][u][r][o][p][e])|([a][s][i][a])|([a][f][r][i][c][a])|([w][o][r][l][d]))$";
+}

--- a/src/main/java/com/football/api/models/CountryLeaguesResponse.java
+++ b/src/main/java/com/football/api/models/CountryLeaguesResponse.java
@@ -1,0 +1,12 @@
+package com.football.api.models;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class CountryLeaguesResponse {
+    private String name;
+}

--- a/src/main/java/com/football/api/service/CountryLeagueService.java
+++ b/src/main/java/com/football/api/service/CountryLeagueService.java
@@ -1,0 +1,51 @@
+package com.football.api.service;
+
+import com.football.api.models.CountryLeaguesResponse;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class CountryLeagueService {
+
+    private final RestTemplate restTemplate;
+
+    public CountryLeagueService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public List<CountryLeaguesResponse> getCountryLeaguesByContinent(String continent, String subscriptionKey) throws ParseException {
+        String sportDataURL =
+                "https://app.sportdataapi.com/api/v1/soccer/countries?apikey=" + subscriptionKey + "&continent=" + continent;
+
+        ResponseEntity<String> response = restTemplate.getForEntity(sportDataURL, String.class);
+
+        JSONParser parser = new JSONParser();
+        JSONObject jsonObject = (JSONObject) parser.parse(response.getBody());
+        List<CountryLeaguesResponse> countryLeaguesResponseList = new ArrayList<>();
+
+        JSONObject data = (JSONObject) jsonObject.get("data");
+        data.values().stream().forEach(o -> {
+            JSONObject jsonObjectO = null;
+            try {
+                jsonObjectO = (JSONObject) parser.parse(o.toString());
+            } catch (ParseException e) {
+                CountryLeaguesResponse countryLeaguesResponse = new CountryLeaguesResponse();
+                countryLeaguesResponse.setName("FAILED TO PARSE");
+                countryLeaguesResponseList.add(countryLeaguesResponse);
+            }
+            CountryLeaguesResponse countryLeaguesResponse = new CountryLeaguesResponse();
+            countryLeaguesResponse.setName(jsonObjectO.get("name").toString());
+            countryLeaguesResponseList.add(countryLeaguesResponse);
+        });
+
+        return countryLeaguesResponseList;
+    }
+
+}

--- a/src/main/java/com/football/api/web/rest/CountryLeagueController.java
+++ b/src/main/java/com/football/api/web/rest/CountryLeagueController.java
@@ -1,0 +1,34 @@
+package com.football.api.web.rest;
+
+import com.football.api.config.Constants;
+import com.football.api.models.CountryLeaguesResponse;
+import com.football.api.service.CountryLeagueService;
+import org.json.simple.parser.ParseException;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
+import java.util.List;
+
+@RestController
+@Validated
+public class CountryLeagueController {
+
+    private final CountryLeagueService countryLeagueService;
+
+    public CountryLeagueController(CountryLeagueService countryLeagueService) {
+        this.countryLeagueService = countryLeagueService;
+    }
+
+    @GetMapping("/leagues-in-continent")
+    public List<CountryLeaguesResponse> getLeaguesByContinent(@Pattern(regexp = Constants.VALID_CONTINENT_VALUES, message = "Valid Continents Values are europe,asia,africa,world")
+                                                                 @Valid @RequestParam String continent,
+                                                              @RequestHeader("subscription-key") String subscriptionKey) throws ParseException {
+        return countryLeagueService.getCountryLeaguesByContinent(continent, subscriptionKey);
+    }
+}


### PR DESCRIPTION
Added endpoint leagues-by-continent to get the names of all the leagues played in the continent entered by the user.
Request Param - continent
Request Header - subscription-key

![image](https://user-images.githubusercontent.com/36205547/180589603-b0874af9-b266-4fc8-84e5-bbe2f94b9f1c.png)
